### PR TITLE
Updated 'spool2klipper.cfg' to contain the correct macro name for when spool is cleared.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ When spool data is to be sent to Klipper, spool2klipper looks for gcode macros w
 `_SPOOLMAN_SET_FIELD_`_fieldname_. Ie:
 `_SPOOLMAN_SET_FIELD_filament_id`
 
-The macro will be called with the argument `VALUE=`_fields-value_.
+The macro will be called with the argument `VALUE=`_fields-value_ which stores the _fieldname_
+and _fields-value_ into the printer `save_variables`.
 
-If the active spool is cleared in Moonraker, this agent will call (if available):
-`_SPOOLMAN_CLEAR_FIELDS`
+When you select a different spool, or if the active spool is ejected, this agent will call
+(if available): `_SPOOLMAN_CLEAR_FIELDS`
 
-After all the macros have been called, _SPOOLMAN_DONE will be called, if available
-`_SPOOLMAN_DONE`
+After all the macros have been called, a _MSG_ will be sent to the terminal via 
+`_SPOOLMAN_DONE` if available.
 
 Add gcode macros to Klipper's config to receive and handle the fields you are interested in.
 
@@ -70,7 +71,7 @@ gcode:
 
 ```
 
-## Run automaticly with systemd
+## Run automatically with systemd
 
 Copy spool2klippper.service to `/etc/systemd/system`, then run:
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ When spool data is to be sent to Klipper, spool2klipper looks for gcode macros w
 The macro will be called with the argument `VALUE=`_fields-value_ which stores the _fieldname_
 and _fields-value_ into the printer `save_variables`.
 
-When you select a different spool, or if the active spool is ejected, this agent will call
-(if available): `_SPOOLMAN_CLEAR_FIELDS`
+When a new spool is loaded, or if the active spool is ejected, this agent will call 
+`_SPOOLMAN_CLEAR_FIELDS` (if available) before storing new fields. This will ensure all previously 
+stored values are cleared in the event there are filaments with empty fields.
 
 After all the macros have been called, a _MSG_ will be sent to the terminal via 
 `_SPOOLMAN_DONE` if available.

--- a/klipper-example-macros.cfg
+++ b/klipper-example-macros.cfg
@@ -12,13 +12,13 @@ gcode:
     {action_respond_info("Parameter 'VALUE' is required")}
   {% endif %}
 
-[gcode_macro _SPOOLMAN_CLEAR_SPOOL]
-description: Removes spool info
+[gcode_macro _SPOOLMAN_CLEAR_FIELDS]
+description: Removes all saved spool info
 gcode:
     SAVE_VARIABLE VARIABLE=active_filament_id VALUE=None
-    RESPOND MSG="Clearing active_filament_id"
+    RESPOND MSG="Stored fields have been cleared"
 
 [gcode_macro _SPOOLMAN_DONE]
-description: The data was transferred
+description: Notification that new spool data has been saved
 gcode:
-    RESPOND TYPE=command MSG="CHANGE FILAMENT"
+    RESPOND TYPE=command MSG="New fields have been saved as variables"

--- a/klipper-example-macros.cfg
+++ b/klipper-example-macros.cfg
@@ -12,7 +12,7 @@ gcode:
     {action_respond_info("Parameter 'VALUE' is required")}
   {% endif %}
 
-[gcode_macro _SPOOLMAN_CLEAR_FIELDS]
+[gcode_macro _SPOOLMAN_CLEAR_SPOOL]
 description: Removes spool info
 gcode:
     SAVE_VARIABLE VARIABLE=active_filament_id VALUE=None

--- a/spool2klipper.cfg
+++ b/spool2klipper.cfg
@@ -11,7 +11,7 @@ klipper_spool_set_macro_prefix = "_SPOOLMAN_SET_FIELD_"
 
 # The name of the gcode macro to call when the spool active id is
 # cleared in moonraker.
-klipper_spool_clear_macro = "_SPOOLMAN_CLEAR_SPOOL"
+klipper_spool_clear_macro = "_SPOOLMAN_CLEAR_FIELDS"
 
 # The name of the gcode macro that is called when all other macros have been executed
 klipper_spool_done = "_SPOOLMAN_DONE"

--- a/spool2klipper.py
+++ b/spool2klipper.py
@@ -96,6 +96,7 @@ class Spool2Klipper:
                     spool_data: Dict[str, Any] = spool_data
                     logging.info("Fetched Spool data for ID %s", spool_id)
                     logging.debug("Got data from Spoolman: %s", spool_data)
+                    await self._run_gcode(self.klipper_spool_clear_macro)
                     await self._call_klipper_with_data(
                         self.klipper_spool_set_macro_prefix,
                         spool_data,


### PR DESCRIPTION
Earlier I updated the example macros and readme.md to refer to the macro name `_SPOOLMAN_CLEAR_FIELDS` but apparently I forgot to also update the `spool2klipper.cfg` file to reflect this updated macro name.

**Change made to `spool2klipper.cfg:**

Changed this line:
``klipper_spool_clear_macro = "_SPOOLMAN_CLEAR_SPOOL"``

To this:
``klipper_spool_clear_macro = "_SPOOLMAN_CLEAR_FIELDS"``